### PR TITLE
[codex] add wavefront renderer pass manifests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,10 @@ The format is based on **[Keep a Changelog](https://keepachangelog.com/en/1.1.0/
 ## [Unreleased]
 
 - **Added**
-  - (placeholder)
+  - Added `createWavefrontRendererPassManifest(...)` and
+    `wavefrontRendererStageFamilies` for queue-backed wavefront renderer pass
+    DAGs, including BVH leaf sorting/materialization, BVH build levels,
+    breadth-first bounce stages, accumulation, and denoise joins.
 
 - **Changed**
   - (placeholder)

--- a/README.md
+++ b/README.md
@@ -191,6 +191,41 @@ The helper publishes one chunk-local DAG per stable snapshot, keeps joins local
 to chunk stage boundaries, and rejects render-preparation manifests that try to
 mutate authoritative simulation state.
 
+Wavefront renderer packages can publish queue-ready pass DAGs with
+`createWavefrontRendererPassManifest(...)`:
+
+```js
+import { createWavefrontRendererPassManifest } from "@plasius/gpu-worker";
+
+const manifest = createWavefrontRendererPassManifest({
+  frameId: "frame-42",
+  queueClass: "render",
+  tileCount: 16,
+  maxDepth: 6,
+  tilePixelCapacity: 128 * 128,
+  triangleCount: 7,
+  bvhLeafSortCapacity: 8,
+  bvhSortStages: [
+    { compareDistance: 1, sequenceSize: 2 },
+    { compareDistance: 2, sequenceSize: 4 },
+  ],
+  bvhBuildLevels: [
+    { start: 3, count: 3 },
+    { start: 1, count: 2 },
+    { start: 0, count: 1 },
+  ],
+});
+
+console.log(manifest.graph.topologicalOrder);
+console.log(manifest.graph.priorityLanes[0]);
+```
+
+The wavefront manifest models BVH triangle assembly, GPU leaf sorting, sorted
+leaf materialization, bottom-up BVH build levels, primary rays, per-bounce
+intersection/surface/contribution/continuation/compaction stages, accumulation,
+and optional denoise as DAG jobs. This gives renderer packages a shared queue
+shape before those stages move fully behind the lock-free worker runtime.
+
 ## What this is
 - A minimal GPU worker layer that combines a lock-free queue with user WGSL jobs.
 - A helper to assemble WGSL modules with queue helpers included.

--- a/demo/index.html
+++ b/demo/index.html
@@ -11,6 +11,7 @@
     <script type="importmap">
       {
         "imports": {
+          "@plasius/gpu-shared": "../node_modules/@plasius/gpu-shared/dist/index.js",
           "@plasius/gpu-lock-free-queue": "../node_modules/@plasius/gpu-lock-free-queue/dist/index.js"
         }
       }

--- a/demo/main.js
+++ b/demo/main.js
@@ -5,7 +5,7 @@ import {
   loadJobWgsl,
   loadWorkerWgsl,
 } from "../dist/index.js";
-import { mountGpuShowcase } from "../node_modules/@plasius/gpu-shared/dist/index.js";
+import { mountGpuShowcase } from "@plasius/gpu-shared";
 
 const root = globalThis.document?.getElementById("app");
 if (!root) {

--- a/docs/adrs/adr-0008: Wavefront Renderer Worker Manifests.md
+++ b/docs/adrs/adr-0008: Wavefront Renderer Worker Manifests.md
@@ -1,0 +1,68 @@
+# ADR-0008: Wavefront Renderer Worker Manifests
+
+## Status
+
+Accepted
+
+## Context
+
+`@plasius/gpu-worker` already supports flat worker loops and DAG-oriented scene
+preparation manifests. The wavefront path-tracing backlog needs one more
+reusable contract layer: renderer packages must describe bounce-ordered pass
+queues, BVH preparation stages, accumulation, and optional denoise without
+reimplementing scheduler semantics inside each `gpu-*` package.
+
+Without a shared manifest helper, the same orchestration rules would drift
+across renderer, lighting, performance, and diagnostics packages. That would
+make queue-class budgeting harder, complicate DAG validation, and make bounce
+ordering less trustworthy.
+
+## Decision
+
+`@plasius/gpu-worker` will expose a first-class wavefront renderer manifest
+helper through `createWavefrontRendererPassManifest(...)` and the
+`wavefrontRendererStageFamilies` contract.
+
+The helper standardizes the reusable worker/DAG shape for:
+
+- BVH triangle assembly, optional leaf sorting, leaf materialization, and
+  bottom-up BVH build levels
+- primary ray generation
+- per-bounce intersection, surface resolution, contribution, continuation, and
+  compaction
+- tile-local accumulation and optional frame-level denoise
+
+The helper must:
+
+- preserve breadth-first bounce dependencies
+- keep queue-class metadata explicit so `@plasius/gpu-performance` can budget
+  the work
+- reject invalid extra dependencies and cycles before packages reach GPU
+  execution
+- stay reusable across renderer-adjacent packages instead of encoding
+  renderer-private WGSL details
+
+## Consequences
+
+- Positive: renderer packages share one worker-manifest contract for
+  bounce-ordered wavefront scheduling.
+- Positive: diagnostics, budgeting, and queue instrumentation can key off the
+  same stable stage-family vocabulary.
+- Positive: tests can validate DAG ordering without requiring GPU execution.
+- Neutral: individual packages still own shader logic and pass payload details;
+  this helper standardizes orchestration only.
+
+## Rejected Alternatives
+
+- Keep wavefront pass manifests package-local in each renderer package:
+  rejected because it would duplicate queue and dependency semantics.
+- Add a separate wavefront scheduler package:
+  rejected because `@plasius/gpu-worker` already owns the reusable worker/DAG
+  contract surface.
+
+## Follow-On Work
+
+- Feed the manifest stage families into `@plasius/gpu-debug` diagnostics and
+  `@plasius/gpu-performance` budget integrations.
+- Reuse the helper from the remaining wavefront renderer stories and package
+  tasks instead of growing repo-local DAG builders.

--- a/docs/adrs/index.md
+++ b/docs/adrs/index.md
@@ -7,3 +7,4 @@
 - [ADR-0005: Optional Worker Loop Telemetry Hooks](./adr-0005:%20Optional%20Worker%20Loop%20Telemetry%20Hooks.md)
 - [ADR-0006: Flat and DAG Queue Assembly Modes](./adr-0006:%20Flat%20and%20DAG%20Queue%20Assembly%20Modes.md)
 - [ADR-0007: Snapshot-Driven Scene Preparation DAGs](./adr-0007:%20Snapshot-Driven%20Scene%20Preparation%20DAGs.md)
+- [ADR-0008: Wavefront Renderer Worker Manifests](./adr-0008:%20Wavefront%20Renderer%20Worker%20Manifests.md)

--- a/src/index.js
+++ b/src/index.js
@@ -728,6 +728,601 @@ export function createWorkerLoop(options = {}) {
   };
 }
 
+export const wavefrontRendererStageFamilies = Object.freeze([
+  "bvhTriangleAssembly",
+  "bvhLeafSort",
+  "bvhLeafMaterialization",
+  "bvhLevelBuild",
+  "primaryRayGeneration",
+  "intersection",
+  "surfaceResolution",
+  "contribution",
+  "continuation",
+  "compaction",
+  "accumulation",
+  "denoise",
+]);
+
+const wavefrontStagePriorityWeights = Object.freeze({
+  bvhTriangleAssembly: 1000,
+  bvhLeafSort: 990,
+  bvhLeafMaterialization: 985,
+  bvhLevelBuild: 980,
+  primaryRayGeneration: 900,
+  intersection: 860,
+  surfaceResolution: 820,
+  contribution: 780,
+  continuation: 760,
+  compaction: 740,
+  accumulation: 700,
+  denoise: 640,
+});
+
+function assertWavefrontIdentifier(name, value) {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new Error(`${name} must be a non-empty string.`);
+  }
+  return value.trim();
+}
+
+function readWavefrontPositiveInteger(name, value, fallback) {
+  const candidate = value === undefined ? fallback : value;
+  if (
+    typeof candidate !== "number" ||
+    !Number.isInteger(candidate) ||
+    candidate <= 0 ||
+    !Number.isFinite(candidate)
+  ) {
+    throw new Error(`${name} must be a positive integer.`);
+  }
+  return candidate;
+}
+
+function readWavefrontNonNegativeInteger(name, value, fallback = 0) {
+  const candidate = value === undefined ? fallback : value;
+  if (
+    typeof candidate !== "number" ||
+    !Number.isInteger(candidate) ||
+    candidate < 0 ||
+    !Number.isFinite(candidate)
+  ) {
+    throw new Error(`${name} must be a non-negative integer.`);
+  }
+  return candidate;
+}
+
+function normalizeWavefrontBvhBuildLevels(levels) {
+  if (levels === undefined) {
+    return [];
+  }
+  if (!Array.isArray(levels)) {
+    throw new Error("bvhBuildLevels must be an array when provided.");
+  }
+  return levels.map((level, index) => {
+    if (!level || typeof level !== "object" || Array.isArray(level)) {
+      throw new Error(`bvhBuildLevels[${index}] must be an object.`);
+    }
+    return Object.freeze({
+      start: readWavefrontNonNegativeInteger(
+        `bvhBuildLevels[${index}].start`,
+        level.start
+      ),
+      count: readWavefrontPositiveInteger(
+        `bvhBuildLevels[${index}].count`,
+        level.count,
+        1
+      ),
+    });
+  });
+}
+
+function normalizeWavefrontBvhSortStages(stages) {
+  if (stages === undefined) {
+    return [];
+  }
+  if (!Array.isArray(stages)) {
+    throw new Error("bvhSortStages must be an array when provided.");
+  }
+  return stages.map((stage, index) => {
+    if (!stage || typeof stage !== "object" || Array.isArray(stage)) {
+      throw new Error(`bvhSortStages[${index}] must be an object.`);
+    }
+    return Object.freeze({
+      compareDistance: readWavefrontPositiveInteger(
+        `bvhSortStages[${index}].compareDistance`,
+        stage.compareDistance,
+        1
+      ),
+      sequenceSize: readWavefrontPositiveInteger(
+        `bvhSortStages[${index}].sequenceSize`,
+        stage.sequenceSize,
+        2
+      ),
+    });
+  });
+}
+
+function createWavefrontJob({
+  frameId,
+  id,
+  stageFamily,
+  queueClass,
+  dependencies,
+  tileIndex = null,
+  bounce = null,
+  priorityOffset = 0,
+  workItemCount = 1,
+  bvhLevelIndex = null,
+  bvhNodeStart = null,
+  bvhNodeCount = null,
+  bvhSortStageIndex = null,
+  bvhCompareDistance = null,
+  bvhSequenceSize = null,
+}) {
+  const priority = (wavefrontStagePriorityWeights[stageFamily] ?? 0) + priorityOffset;
+  return Object.freeze({
+    id,
+    frameId,
+    stageFamily,
+    queueClass,
+    jobType: `wavefront.${stageFamily}`,
+    schedulerMode: "dag",
+    dependencies: Object.freeze(dependencies),
+    dependencyCount: dependencies.length,
+    root: dependencies.length === 0,
+    priority,
+    workItemCount,
+    tileIndex,
+    bounce,
+    bvhLevelIndex,
+    bvhNodeStart,
+    bvhNodeCount,
+    bvhSortStageIndex,
+    bvhCompareDistance,
+    bvhSequenceSize,
+    authority: "visual",
+    mutatesSimulation: false,
+  });
+}
+
+function buildWavefrontPriorityLanes(jobs) {
+  const lanes = new Map();
+  for (const job of jobs) {
+    const lane = lanes.get(job.priority) ?? {
+      priority: job.priority,
+      jobIds: [],
+      queueClasses: [],
+    };
+    lane.jobIds.push(job.id);
+    if (!lane.queueClasses.includes(job.queueClass)) {
+      lane.queueClasses.push(job.queueClass);
+    }
+    lanes.set(job.priority, lane);
+  }
+
+  return Object.freeze(
+    [...lanes.values()]
+      .sort((left, right) => right.priority - left.priority)
+      .map((lane) =>
+        Object.freeze({
+          priority: lane.priority,
+          jobIds: Object.freeze([...lane.jobIds]),
+          queueClasses: Object.freeze([...lane.queueClasses]),
+          jobCount: lane.jobIds.length,
+        })
+      )
+  );
+}
+
+function normalizeWavefrontExtraDependencies(extraDependencies) {
+  if (extraDependencies === undefined) {
+    return new Map();
+  }
+  if (!extraDependencies || typeof extraDependencies !== "object" || Array.isArray(extraDependencies)) {
+    throw new Error("extraDependencies must be an object keyed by job id.");
+  }
+  return new Map(
+    Object.entries(extraDependencies).map(([jobId, dependencies]) => {
+      if (!Array.isArray(dependencies)) {
+        throw new Error(`extraDependencies.${jobId} must be an array.`);
+      }
+      return [
+        assertWavefrontIdentifier("extraDependencies key", jobId),
+        Object.freeze(
+          dependencies.map((dependency, index) =>
+            assertWavefrontIdentifier(
+              `extraDependencies.${jobId}[${index}]`,
+              dependency
+            )
+          )
+        ),
+      ];
+    })
+  );
+}
+
+function applyWavefrontExtraDependencies(jobs, extraDependencies) {
+  if (extraDependencies.size === 0) {
+    return jobs;
+  }
+  const jobIds = new Set(jobs.map((job) => job.id));
+  for (const [jobId, dependencies] of extraDependencies) {
+    if (!jobIds.has(jobId)) {
+      throw new Error(`extraDependencies references unknown job "${jobId}".`);
+    }
+    for (const dependency of dependencies) {
+      if (!jobIds.has(dependency)) {
+        throw new Error(
+          `Job "${jobId}" depends on unknown job "${dependency}".`
+        );
+      }
+      if (dependency === jobId) {
+        throw new Error(`Job "${jobId}" cannot depend on itself.`);
+      }
+    }
+  }
+
+  return Object.freeze(
+    jobs.map((job) => {
+      const additions = extraDependencies.get(job.id) ?? [];
+      if (additions.length === 0) {
+        return job;
+      }
+      const dependencies = Object.freeze(
+        [...new Set([...job.dependencies, ...additions])]
+      );
+      return Object.freeze({
+        ...job,
+        dependencies,
+        dependencyCount: dependencies.length,
+        root: dependencies.length === 0,
+      });
+    })
+  );
+}
+
+function buildWavefrontTopologicalOrder(jobs) {
+  const jobIds = new Set(jobs.map((job) => job.id));
+  for (const job of jobs) {
+    for (const dependency of job.dependencies) {
+      if (!jobIds.has(dependency)) {
+        throw new Error(
+          `Job "${job.id}" depends on unknown job "${dependency}".`
+        );
+      }
+      if (dependency === job.id) {
+        throw new Error(`Job "${job.id}" cannot depend on itself.`);
+      }
+    }
+  }
+
+  const indegree = new Map(jobs.map((job) => [job.id, job.dependencies.length]));
+  const dependentsById = new Map(jobs.map((job) => [job.id, []]));
+  const jobById = new Map(jobs.map((job) => [job.id, job]));
+  for (const job of jobs) {
+    for (const dependency of job.dependencies) {
+      dependentsById.get(dependency)?.push(job.id);
+    }
+  }
+
+  const queue = jobs
+    .filter((job) => job.dependencies.length === 0)
+    .sort((left, right) => right.priority - left.priority)
+    .map((job) => job.id);
+  const order = [];
+
+  while (queue.length > 0) {
+    const currentId = queue.shift();
+    if (!currentId) {
+      continue;
+    }
+    order.push(currentId);
+    const unlocked = [];
+    for (const dependentId of dependentsById.get(currentId) ?? []) {
+      const next = (indegree.get(dependentId) ?? 0) - 1;
+      indegree.set(dependentId, next);
+      if (next === 0) {
+        unlocked.push(dependentId);
+      }
+    }
+    unlocked
+      .sort(
+        (left, right) =>
+          (jobById.get(right)?.priority ?? 0) -
+          (jobById.get(left)?.priority ?? 0)
+      )
+      .forEach((jobId) => {
+        queue.push(jobId);
+      });
+  }
+
+  if (order.length !== jobs.length) {
+    throw new Error("Wavefront renderer manifest contains a cycle.");
+  }
+
+  return Object.freeze(order);
+}
+
+export function createWavefrontRendererPassManifest(options = {}) {
+  const frameId = assertWavefrontIdentifier("frameId", options.frameId);
+  const queueClass = assertWavefrontIdentifier(
+    "queueClass",
+    options.queueClass ?? "render"
+  );
+  const tileCount = readWavefrontPositiveInteger(
+    "tileCount",
+    options.tileCount,
+    1
+  );
+  const maxDepth = readWavefrontPositiveInteger(
+    "maxDepth",
+    options.maxDepth,
+    1
+  );
+  const tilePixelCapacity = readWavefrontPositiveInteger(
+    "tilePixelCapacity",
+    options.tilePixelCapacity,
+    1
+  );
+  const bvhBuildLevels = normalizeWavefrontBvhBuildLevels(
+    options.bvhBuildLevels
+  );
+  const bvhSortStages = normalizeWavefrontBvhSortStages(
+    options.bvhSortStages
+  );
+  const bvhLeafSortCapacity = readWavefrontNonNegativeInteger(
+    "bvhLeafSortCapacity",
+    options.bvhLeafSortCapacity,
+    0
+  );
+  const includeBvhBuild =
+    options.includeBvhBuild === true ||
+    bvhBuildLevels.length > 0 ||
+    bvhSortStages.length > 0;
+  const includeDenoise = options.denoise !== false;
+  const jobs = [];
+  let accelerationDependency = null;
+
+  if (includeBvhBuild) {
+    const assemblyId = `${frameId}:bvh:triangleAssembly`;
+    jobs.push(
+      createWavefrontJob({
+        frameId,
+        id: assemblyId,
+        stageFamily: "bvhTriangleAssembly",
+        queueClass,
+        dependencies: [],
+        workItemCount: readWavefrontPositiveInteger(
+          "triangleCount",
+          options.triangleCount,
+          1
+        ),
+      })
+    );
+    accelerationDependency = assemblyId;
+
+    bvhSortStages.forEach((sortStage, index) => {
+      const sortId = `${frameId}:bvh:sort-${index}`;
+      jobs.push(
+        createWavefrontJob({
+          frameId,
+          id: sortId,
+          stageFamily: "bvhLeafSort",
+          queueClass,
+          dependencies: [accelerationDependency],
+          bvhSortStageIndex: index,
+          bvhCompareDistance: sortStage.compareDistance,
+          bvhSequenceSize: sortStage.sequenceSize,
+          workItemCount: bvhLeafSortCapacity,
+          priorityOffset: -index,
+        })
+      );
+      accelerationDependency = sortId;
+    });
+
+    const materializationId = `${frameId}:bvh:leafMaterialization`;
+    jobs.push(
+      createWavefrontJob({
+        frameId,
+        id: materializationId,
+        stageFamily: "bvhLeafMaterialization",
+        queueClass,
+        dependencies: [accelerationDependency],
+        workItemCount: readWavefrontPositiveInteger(
+          "triangleCount",
+          options.triangleCount,
+          1
+        ),
+      })
+    );
+    accelerationDependency = materializationId;
+
+    bvhBuildLevels.forEach((level, index) => {
+      const levelId = `${frameId}:bvh:level-${index}`;
+      jobs.push(
+        createWavefrontJob({
+          frameId,
+          id: levelId,
+          stageFamily: "bvhLevelBuild",
+          queueClass,
+          dependencies: [accelerationDependency],
+          bvhLevelIndex: index,
+          bvhNodeStart: level.start,
+          bvhNodeCount: level.count,
+          workItemCount: level.count,
+          priorityOffset: -index,
+        })
+      );
+      accelerationDependency = levelId;
+    });
+  }
+
+  const tileAccumulationJobs = [];
+  for (let tileIndex = 0; tileIndex < tileCount; tileIndex += 1) {
+    const tilePrefix = `${frameId}:tile-${tileIndex}`;
+    const primaryId = `${tilePrefix}:primaryRayGeneration`;
+    jobs.push(
+      createWavefrontJob({
+        frameId,
+        id: primaryId,
+        stageFamily: "primaryRayGeneration",
+        queueClass,
+        dependencies: accelerationDependency ? [accelerationDependency] : [],
+        tileIndex,
+        workItemCount: tilePixelCapacity,
+      })
+    );
+
+    let previousBounceDependency = primaryId;
+    for (let bounce = 0; bounce < maxDepth; bounce += 1) {
+      const bouncePrefix = `${tilePrefix}:bounce-${bounce}`;
+      const intersectionId = `${bouncePrefix}:intersection`;
+      const surfaceId = `${bouncePrefix}:surfaceResolution`;
+      const contributionId = `${bouncePrefix}:contribution`;
+      const continuationId = `${bouncePrefix}:continuation`;
+      const compactionId = `${bouncePrefix}:compaction`;
+
+      jobs.push(
+        createWavefrontJob({
+          frameId,
+          id: intersectionId,
+          stageFamily: "intersection",
+          queueClass,
+          dependencies: [previousBounceDependency],
+          tileIndex,
+          bounce,
+          workItemCount: tilePixelCapacity,
+        }),
+        createWavefrontJob({
+          frameId,
+          id: surfaceId,
+          stageFamily: "surfaceResolution",
+          queueClass,
+          dependencies: [intersectionId],
+          tileIndex,
+          bounce,
+          workItemCount: tilePixelCapacity,
+        }),
+        createWavefrontJob({
+          frameId,
+          id: contributionId,
+          stageFamily: "contribution",
+          queueClass,
+          dependencies: [surfaceId],
+          tileIndex,
+          bounce,
+          workItemCount: tilePixelCapacity,
+        }),
+        createWavefrontJob({
+          frameId,
+          id: continuationId,
+          stageFamily: "continuation",
+          queueClass,
+          dependencies: [surfaceId],
+          tileIndex,
+          bounce,
+          workItemCount: tilePixelCapacity,
+        }),
+        createWavefrontJob({
+          frameId,
+          id: compactionId,
+          stageFamily: "compaction",
+          queueClass,
+          dependencies: [contributionId, continuationId],
+          tileIndex,
+          bounce,
+          workItemCount: tilePixelCapacity,
+        })
+      );
+      previousBounceDependency = compactionId;
+    }
+
+    const accumulationId = `${tilePrefix}:accumulation`;
+    jobs.push(
+      createWavefrontJob({
+        frameId,
+        id: accumulationId,
+        stageFamily: "accumulation",
+        queueClass,
+        dependencies: [previousBounceDependency],
+        tileIndex,
+        workItemCount: tilePixelCapacity,
+      })
+    );
+    tileAccumulationJobs.push(accumulationId);
+  }
+
+  let denoiseJobId = null;
+  if (includeDenoise) {
+    denoiseJobId = `${frameId}:denoise`;
+    jobs.push(
+      createWavefrontJob({
+        frameId,
+        id: denoiseJobId,
+        stageFamily: "denoise",
+        queueClass,
+        dependencies: tileAccumulationJobs,
+        workItemCount: tileCount * tilePixelCapacity,
+      })
+    );
+  }
+
+  const finalizedJobs = applyWavefrontExtraDependencies(
+    Object.freeze(jobs),
+    normalizeWavefrontExtraDependencies(options.extraDependencies)
+  );
+  const dependentsById = new Map(finalizedJobs.map((job) => [job.id, []]));
+  for (const job of finalizedJobs) {
+    for (const dependency of job.dependencies) {
+      dependentsById.get(dependency)?.push(job.id);
+    }
+  }
+  const jobsWithDependents = Object.freeze(
+    finalizedJobs.map((job) =>
+      Object.freeze({
+        ...job,
+        dependents: Object.freeze(dependentsById.get(job.id) ?? []),
+        dependentCount: dependentsById.get(job.id)?.length ?? 0,
+        localJoin:
+          job.dependencies.length > 1 &&
+          job.dependencies.every((dependency) => dependency.startsWith(`${frameId}:tile-${job.tileIndex}`)),
+      })
+    )
+  );
+
+  return Object.freeze({
+    schemaVersion: 1,
+    owner: "wavefront-renderer",
+    schedulerMode: "dag",
+    frameId,
+    queueClass,
+    tileCount,
+    maxDepth,
+    tilePixelCapacity,
+    denoise: includeDenoise,
+    bvhBuildLevels: Object.freeze(bvhBuildLevels),
+    bvhSortStages: Object.freeze(bvhSortStages),
+    bvhLeafSortCapacity,
+    jobs: jobsWithDependents,
+    graph: Object.freeze({
+      schedulerMode: "dag",
+      jobCount: jobsWithDependents.length,
+      tileCount,
+      maxDepth,
+      roots: Object.freeze(
+        jobsWithDependents.filter((job) => job.root).map((job) => job.id)
+      ),
+      topologicalOrder: buildWavefrontTopologicalOrder(jobsWithDependents),
+      priorityLanes: buildWavefrontPriorityLanes(jobsWithDependents),
+      bvhBuildLevelCount: bvhBuildLevels.length,
+      bvhSortStageCount: bvhSortStages.length,
+      denoiseJobId,
+      tileAccumulationJobs: Object.freeze(tileAccumulationJobs),
+      queueClasses: Object.freeze([...new Set(jobsWithDependents.map((job) => job.queueClass))]),
+    }),
+  });
+}
+
 export const scenePreparationRepresentationBands = Object.freeze([
   "near",
   "mid",

--- a/tests/wavefront-renderer-pass-manifest.test.js
+++ b/tests/wavefront-renderer-pass-manifest.test.js
@@ -1,0 +1,125 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+const originalImportMetaUrl = globalThis.__IMPORT_META_URL__;
+globalThis.__IMPORT_META_URL__ = new URL("../src/index.js", import.meta.url);
+const {
+  createWavefrontRendererPassManifest,
+  wavefrontRendererStageFamilies,
+} = await import("../src/index.js");
+if (typeof originalImportMetaUrl === "undefined") {
+  delete globalThis.__IMPORT_META_URL__;
+} else {
+  globalThis.__IMPORT_META_URL__ = originalImportMetaUrl;
+}
+
+test("wavefront renderer manifest models BVH levels before primary rays", () => {
+  const manifest = createWavefrontRendererPassManifest({
+    frameId: "frame-200",
+    queueClass: "render",
+    tileCount: 1,
+    maxDepth: 2,
+    tilePixelCapacity: 256,
+    triangleCount: 7,
+    bvhLeafSortCapacity: 8,
+    bvhSortStages: [
+      { compareDistance: 1, sequenceSize: 2 },
+      { compareDistance: 2, sequenceSize: 4 },
+    ],
+    bvhBuildLevels: [
+      { start: 3, count: 3 },
+      { start: 1, count: 2 },
+      { start: 0, count: 1 },
+    ],
+  });
+  const primary = manifest.jobs.find(
+    (job) => job.stageFamily === "primaryRayGeneration"
+  );
+  const firstLevel = manifest.jobs.find(
+    (job) => job.id === "frame-200:bvh:level-0"
+  );
+  const firstSort = manifest.jobs.find(
+    (job) => job.id === "frame-200:bvh:sort-0"
+  );
+  const materialization = manifest.jobs.find(
+    (job) => job.id === "frame-200:bvh:leafMaterialization"
+  );
+  const lastLevel = manifest.jobs.find(
+    (job) => job.id === "frame-200:bvh:level-2"
+  );
+
+  assert.deepEqual(wavefrontRendererStageFamilies.slice(0, 6), [
+    "bvhTriangleAssembly",
+    "bvhLeafSort",
+    "bvhLeafMaterialization",
+    "bvhLevelBuild",
+    "primaryRayGeneration",
+    "intersection",
+  ]);
+  assert.deepEqual(manifest.graph.roots, ["frame-200:bvh:triangleAssembly"]);
+  assert.deepEqual(firstSort.dependencies, ["frame-200:bvh:triangleAssembly"]);
+  assert.deepEqual(materialization.dependencies, ["frame-200:bvh:sort-1"]);
+  assert.deepEqual(firstLevel.dependencies, ["frame-200:bvh:leafMaterialization"]);
+  assert.deepEqual(lastLevel.dependencies, ["frame-200:bvh:level-1"]);
+  assert.deepEqual(primary.dependencies, ["frame-200:bvh:level-2"]);
+  assert.equal(firstSort.workItemCount, 8);
+  assert.equal(firstSort.bvhCompareDistance, 1);
+  assert.equal(firstLevel.workItemCount, 3);
+  assert.equal(lastLevel.bvhNodeStart, 0);
+  assert.equal(manifest.graph.bvhSortStageCount, 2);
+  assert.equal(manifest.graph.bvhBuildLevelCount, 3);
+});
+
+test("wavefront renderer manifest preserves breadth-first bounce dependencies", () => {
+  const manifest = createWavefrontRendererPassManifest({
+    frameId: "frame-201",
+    tileCount: 2,
+    maxDepth: 2,
+    tilePixelCapacity: 128,
+  });
+  const intersection0 = manifest.jobs.find(
+    (job) => job.id === "frame-201:tile-0:bounce-0:intersection"
+  );
+  const surface0 = manifest.jobs.find(
+    (job) => job.id === "frame-201:tile-0:bounce-0:surfaceResolution"
+  );
+  const compaction0 = manifest.jobs.find(
+    (job) => job.id === "frame-201:tile-0:bounce-0:compaction"
+  );
+  const intersection1 = manifest.jobs.find(
+    (job) => job.id === "frame-201:tile-0:bounce-1:intersection"
+  );
+  const denoise = manifest.jobs.find((job) => job.stageFamily === "denoise");
+
+  assert.deepEqual(intersection0.dependencies, [
+    "frame-201:tile-0:primaryRayGeneration",
+  ]);
+  assert.deepEqual(surface0.dependencies, [intersection0.id]);
+  assert.deepEqual(compaction0.dependencies, [
+    "frame-201:tile-0:bounce-0:contribution",
+    "frame-201:tile-0:bounce-0:continuation",
+  ]);
+  assert.deepEqual(intersection1.dependencies, [compaction0.id]);
+  assert.equal(compaction0.localJoin, true);
+  assert.deepEqual(denoise.dependencies, [
+    "frame-201:tile-0:accumulation",
+    "frame-201:tile-1:accumulation",
+  ]);
+  assert.equal(manifest.graph.queueClasses.includes("render"), true);
+  assert.equal(manifest.graph.topologicalOrder.indexOf(intersection0.id) < manifest.graph.topologicalOrder.indexOf(surface0.id), true);
+});
+
+test("wavefront renderer manifest rejects cyclic pass dependencies", () => {
+  assert.throws(
+    () =>
+      createWavefrontRendererPassManifest({
+        frameId: "frame-cycle",
+        tileCount: 1,
+        maxDepth: 1,
+        extraDependencies: {
+          "frame-cycle:tile-0:primaryRayGeneration": ["frame-cycle:denoise"],
+        },
+      }),
+    /contains a cycle/
+  );
+});


### PR DESCRIPTION
## What changed
- add `createWavefrontRendererPassManifest(...)` and `wavefrontRendererStageFamilies` for reusable bounce-ordered wavefront pass DAGs
- cover BVH stage ordering, breadth-first bounce dependencies, and cycle rejection with tests
- document the new worker-manifest contract in the README, changelog, and ADR index
- fix the demo import map so `@plasius/gpu-shared` resolves from the public package surface

## Why
The wavefront renderer backlog needs a shared worker manifest contract so renderer-adjacent packages can schedule the bounce pipeline consistently instead of duplicating DAG semantics.

## Validation
- `PATH=/Users/philliphounslow/.nvm/versions/node/v24.14.0/bin:$PATH npm test`
- `PATH=/Users/philliphounslow/.nvm/versions/node/v24.14.0/bin:$PATH npm run typecheck`
- `PATH=/Users/philliphounslow/.nvm/versions/node/v24.14.0/bin:$PATH npm run lint`
- `PATH=/Users/philliphounslow/.nvm/versions/node/v24.14.0/bin:$PATH npm run build`
- `PATH=/Users/philliphounslow/.nvm/versions/node/v24.14.0/bin:$PATH npm run test:coverage`
- `PATH=/Users/philliphounslow/.nvm/versions/node/v24.14.0/bin:$PATH npm run pack:check`
