### PR TITLE
feat(worker): drain jobs until queue empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,14 @@ The format is based on **[Keep a Changelog](https://keepachangelog.com/en/1.1.0/
 ## [Unreleased]
 
 - **Added**
-  - (placeholder)
+  - Added ADR-0009 documenting drain-until-empty worker invocation semantics
+    for queue-backed GPU execution.
 
 - **Changed**
-  - (placeholder)
+  - Changed the published worker WGSL entry point so each invocation keeps
+    dequeuing runnable jobs until the queue is empty by default.
+  - Added the `WORKER_MAX_JOBS_PER_INVOCATION` WGSL override constant so
+    callers can optionally bound per-invocation work.
 
 - **Fixed**
   - (placeholder)

--- a/README.md
+++ b/README.md
@@ -71,6 +71,13 @@ Queue assets from `@plasius/gpu-lock-free-queue` already provide that hook. If
 you pass a custom queue source without it, the assembler appends a no-op shim so
 existing flat queue integrations keep working.
 
+By default, each worker invocation now drains the queue until no immediately
+runnable work remains. That means a worker that finishes one job immediately
+attempts to dequeue the next job instead of waiting for a host-side resubmit.
+If a caller needs a fairness or watchdog bound, the published WGSL exposes the
+pipeline override constant `WORKER_MAX_JOBS_PER_INVOCATION`; leaving it at the
+default `0` keeps the drain-until-empty behavior enabled.
+
 To bypass the registry, pass jobs directly:
 ```js
 const shaderCode = await assembleWorkerWgsl(workerWgsl, {
@@ -230,6 +237,8 @@ shape before those stages move fully behind the lock-free worker runtime.
 - A minimal GPU worker layer that combines a lock-free queue with user WGSL jobs.
 - A helper to assemble WGSL modules with queue helpers included.
 - A reference job format for fixed-size job dispatch (u32 indices).
+- A worker execution model where active invocations keep pulling runnable work
+  until the queue is empty unless the caller explicitly bounds them.
 
 ## DAG Queue Modes
 

--- a/docs/adrs/adr-0009: Drain-Until-Empty Worker Invocations.md
+++ b/docs/adrs/adr-0009: Drain-Until-Empty Worker Invocations.md
@@ -1,0 +1,65 @@
+# ADR-0009: Drain-Until-Empty Worker Invocations
+
+## Status
+
+Accepted
+
+## Context
+
+`@plasius/gpu-worker` exists to keep discrete GPU jobs moving through shared
+queue contracts without each package rebuilding its own scheduling layer.
+The previous default worker WGSL shape dequeued at most one job per invocation.
+That was simple, but it leaves throughput on the table for queues that already
+contain more runnable work.
+
+For workloads such as wavefront rendering, fluids, cloth, and lighting refresh,
+the desired behavior is straightforward:
+
+- launch enough invocations to occupy the GPU,
+- let each invocation dequeue work immediately when it finishes,
+- avoid host-side waits or per-job synchronisation while runnable work remains.
+
+That behavior should be the default in the shared worker runtime, not a
+package-local workaround.
+
+## Decision
+
+The published worker WGSL entry point will use drain-until-empty semantics by
+default.
+
+Each worker invocation now:
+
+1. attempts to dequeue a job,
+2. executes `process_job(...)`,
+3. calls `complete_job(...)`,
+4. immediately loops back to dequeue the next runnable job,
+5. exits only when the queue reports no immediately runnable work.
+
+The WGSL also exposes an override constant:
+
+- `WORKER_MAX_JOBS_PER_INVOCATION: u32 = 0u`
+
+The default `0u` means "no worker-local cap; drain until empty". Callers may
+set a positive pipeline constant when they need to bound per-invocation work
+for fairness, watchdog, or latency reasons.
+
+## Consequences
+
+- Positive: queue-backed workloads can keep workers busy without host-side
+  fences between individual jobs.
+- Positive: longer-running or dependency-heavy jobs naturally hold execution
+  resources longer, while shorter jobs let the same invocation pick up more
+  work immediately.
+- Positive: DAG-ready queues benefit as newly unlocked dependents can be
+  consumed by invocations that are already active.
+- Neutral: packages that need stricter fairness can still opt into a bounded
+  per-invocation job limit through the override constant.
+
+## Rejected Alternatives
+
+- Keep one-job-per-invocation semantics and let callers dispatch more often:
+  rejected because it pushes unnecessary synchronisation and cadence policy
+  back to the host.
+- Add package-local drain loops in every consumer package:
+  rejected because `@plasius/gpu-worker` is the shared execution plane and
+  should own this behavior once.

--- a/docs/adrs/index.md
+++ b/docs/adrs/index.md
@@ -8,3 +8,4 @@
 - [ADR-0006: Flat and DAG Queue Assembly Modes](./adr-0006:%20Flat%20and%20DAG%20Queue%20Assembly%20Modes.md)
 - [ADR-0007: Snapshot-Driven Scene Preparation DAGs](./adr-0007:%20Snapshot-Driven%20Scene%20Preparation%20DAGs.md)
 - [ADR-0008: Wavefront Renderer Worker Manifests](./adr-0008:%20Wavefront%20Renderer%20Worker%20Manifests.md)
+- [ADR-0009: Drain-Until-Empty Worker Invocations](./adr-0009:%20Drain-Until-Empty%20Worker%20Invocations.md)

--- a/src/worker.wgsl
+++ b/src/worker.wgsl
@@ -17,22 +17,38 @@ fn payload_word(job_index: u32, word_index: u32) -> u32 {
 // process_job(job_index, job_type, payload_words) must be defined by the
 // job WGSL that you concatenate before this file.
 
+// When left at the default 0, each invocation keeps draining the queue until
+// dequeue() reports no immediately runnable work. Callers can set a positive
+// pipeline override constant to bound per-invocation work when fairness or
+// watchdog constraints matter more than maximum drain throughput.
+override WORKER_MAX_JOBS_PER_INVOCATION: u32 = 0u;
+
 @compute @workgroup_size(64)
 fn worker_main(@builtin(global_invocation_id) gid: vec3<u32>) {
   let idx = gid.x;
-  let job_count = dequeue_job_count();
-  if (idx >= job_count) {
+  let max_output_jobs = dequeue_job_count();
+  if (idx >= max_output_jobs) {
     return;
   }
   if (!queue_config_valid()) {
     return;
   }
-  let ok = dequeue(idx);
-  if (ok == 0u) {
-    return;
-  }
+  var processed_jobs: u32 = 0u;
+  loop {
+    if (
+      WORKER_MAX_JOBS_PER_INVOCATION != 0u &&
+      processed_jobs >= WORKER_MAX_JOBS_PER_INVOCATION
+    ) {
+      break;
+    }
+    let ok = dequeue(idx);
+    if (ok == 0u) {
+      break;
+    }
 
-  let job_info = output_jobs[idx];
-  process_job(idx, job_info.job_type, job_info.payload_words);
-  complete_job(idx);
+    let job_info = output_jobs[idx];
+    process_job(idx, job_info.job_type, job_info.payload_words);
+    complete_job(idx);
+    processed_jobs = processed_jobs + 1u;
+  }
 }

--- a/tests/worker.test.js
+++ b/tests/worker.test.js
@@ -122,6 +122,24 @@ test("loadWorkerWgsl uses fetch for the WGSL body", async () => {
   }
 });
 
+test("loadWorkerWgsl publishes drain-until-empty worker semantics", async () => {
+  const source = await loadWorkerWgsl({
+    fetcher: async () => ({
+      ok: true,
+      async text() {
+        return await import("node:fs/promises").then(({ readFile }) =>
+          readFile(new URL("../src/worker.wgsl", import.meta.url), "utf8")
+        );
+      },
+    }),
+  });
+
+  assert.match(source, /override WORKER_MAX_JOBS_PER_INVOCATION: u32 = 0u;/);
+  assert.match(source, /loop \{/);
+  assert.match(source, /processed_jobs = processed_jobs \+ 1u;/);
+  assert.match(source, /if \(ok == 0u\) \{\s+break;/);
+});
+
 test("assembleWorkerWgsl concatenates queue and worker sources", async () => {
   const queueWgsl = await loadQueueWgsl();
   const workerWgsl = "worker-main";


### PR DESCRIPTION
## Summary
- change the published worker WGSL entry point to drain runnable jobs until the queue is empty by default
- add an optional WGSL override constant to cap per-invocation work when callers need it
- document and test the new worker execution semantics

## Validation
- npm run lint
- npm run audit:npm
- npm run test:coverage
- npm run build
- npm run typecheck
- npm run pack:check