### PR TITLE
fix(cd): fetch release branch before lease push

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -238,6 +238,7 @@ jobs:
           fi
 
           git commit -m "chore(release): persist v${VERSION} metadata"
+          git fetch origin "$RELEASE_BRANCH":"refs/remotes/origin/$RELEASE_BRANCH" || true
           git push -u origin "$RELEASE_BRANCH" --force-with-lease
 
           if [ -n "$(gh pr list --head "$RELEASE_BRANCH" --json number --jq '.[0].number // empty')" ]; then


### PR DESCRIPTION
## Summary
- fetch the release metadata branch before pushing with --force-with-lease in CD
- preserve protected-main release flow for existing release-metadata branches
- unblock reruns of the v0.3.0 publish workflow

## Validation
- npm test
- npm run lint
- npm run build