### PR TITLE
chore: prepare release v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,20 @@ The format is based on **[Keep a Changelog](https://keepachangelog.com/en/1.1.0/
 - **Security**
   - (placeholder)
 
+## [0.3.1] - 2026-06-22
+
+- **Added**
+  - (placeholder)
+
+- **Changed**
+  - (placeholder)
+
+- **Fixed**
+  - (placeholder)
+
+- **Security**
+  - (placeholder)
+
 ## [0.3.0] - 2026-06-17
 
 - **Added**
@@ -335,7 +349,7 @@ The format is based on **[Keep a Changelog](https://keepachangelog.com/en/1.1.0/
 
 ---
 
-[Unreleased]: https://github.com/Plasius-LTD/gpu-worker/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/Plasius-LTD/gpu-worker/compare/v0.3.1...HEAD
 [0.1.0-beta.1]: https://github.com/Plasius-LTD/gpu-worker/releases/tag/v0.1.0-beta.1
 [0.1.0]: https://github.com/Plasius-LTD/gpu-worker/releases/tag/v0.1.0
 [0.1.2]: https://github.com/Plasius-LTD/gpu-worker/releases/tag/v0.1.2
@@ -365,3 +379,4 @@ The format is based on **[Keep a Changelog](https://keepachangelog.com/en/1.1.0/
 [0.1.15]: https://github.com/Plasius-LTD/gpu-worker/releases/tag/v0.1.15
 [0.1.16]: https://github.com/Plasius-LTD/gpu-worker/releases/tag/v0.1.16
 [0.3.0]: https://github.com/Plasius-LTD/gpu-worker/releases/tag/v0.3.0
+[0.3.1]: https://github.com/Plasius-LTD/gpu-worker/releases/tag/v0.3.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@plasius/gpu-worker",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@plasius/gpu-worker",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "funding": [
         {
           "type": "patreon",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@plasius/gpu-worker",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "WebGPU worker runtime with a lock-free job queue for WGSL workloads.",
   "type": "module",
   "sideEffects": false,


### PR DESCRIPTION
## Summary
- prepare `v0.3.1` for publication from protected `main`
- update package metadata to `0.3.1`
- move the current `Unreleased` notes into `0.3.1`

The CD workflow will continue only after this release metadata is present on `main`.