### PR TITLE
chore: refresh gpu-worker dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on **[Keep a Changelog](https://keepachangelog.com/en/1.1.0/
   - (placeholder)
 
 - **Changed**
+  - Refreshed the published `@plasius/gpu-shared` and `@plasius/gpu-lock-free-queue` dependencies to their latest released versions.
   - (placeholder)
 
 - **Fixed**

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,8 +19,8 @@
       ],
       "license": "Apache-2.0",
       "dependencies": {
-        "@plasius/gpu-lock-free-queue": "^0.2.18",
-        "@plasius/gpu-shared": "^0.1.9"
+        "@plasius/gpu-lock-free-queue": "^0.3.2",
+        "@plasius/gpu-shared": "^1.0.1"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -731,9 +731,9 @@
       }
     },
     "node_modules/@plasius/gpu-lock-free-queue": {
-      "version": "0.2.19",
-      "resolved": "https://registry.npmjs.org/@plasius/gpu-lock-free-queue/-/gpu-lock-free-queue-0.2.19.tgz",
-      "integrity": "sha512-poq9obAlDJfBtbdj9ogWI1JKmDb3FXdExfgXwKmMO1EDhXSYUwcIamELUc0ep2wXo/5VAle9u3b+Or5v8zeq5A==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@plasius/gpu-lock-free-queue/-/gpu-lock-free-queue-0.3.2.tgz",
+      "integrity": "sha512-l+1jb31Fm/nelfWXN0qRsJICZeOfoWABEb4DDuJ2Pp4kYglio2h7vnWJ75l5FxD48ME8WU5DRGY6f5Gbayj6gg==",
       "funding": [
         {
           "type": "patreon",
@@ -752,10 +752,41 @@
         "node": ">=24"
       }
     },
-    "node_modules/@plasius/gpu-shared": {
+    "node_modules/@plasius/gpu-lock-free-queue/node_modules/@plasius/gpu-shared": {
       "version": "0.1.20",
       "resolved": "https://registry.npmjs.org/@plasius/gpu-shared/-/gpu-shared-0.1.20.tgz",
       "integrity": "sha512-YsZo1Id+UnVxr1YshrfI/N0DuVfkq7De+W9RZA5daM0STwgelh71G6Kk24Pv893g76nrBuyH0SyTgmhjMvAvTA==",
+      "funding": [
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/c/plasiusltd/membership"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/Plasius-LTD"
+        }
+      ],
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=24"
+      },
+      "peerDependencies": {
+        "@plasius/gpu-renderer": "^0.2.3",
+        "@plasius/translations": "^1.0.17"
+      },
+      "peerDependenciesMeta": {
+        "@plasius/gpu-renderer": {
+          "optional": true
+        },
+        "@plasius/translations": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@plasius/gpu-shared": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@plasius/gpu-shared/-/gpu-shared-1.0.1.tgz",
+      "integrity": "sha512-2+j6Gph/PuGmzTJJI/ZR8qGYfaEjLcN0+8zk/UEctVJyIb9+GMhE1Trkxg7L76qnaeO7g7LHAULwOuTTz5aOZQ==",
       "funding": [
         {
           "type": "patreon",

--- a/package.json
+++ b/package.json
@@ -55,8 +55,8 @@
   "author": "Plasius LTD <development@plasius.co.uk>",
   "license": "Apache-2.0",
   "dependencies": {
-    "@plasius/gpu-shared": "^0.1.9",
-    "@plasius/gpu-lock-free-queue": "^0.2.18"
+    "@plasius/gpu-lock-free-queue": "^0.3.2",
+    "@plasius/gpu-shared": "^1.0.1"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",


### PR DESCRIPTION
## Summary
- refresh the published @plasius/gpu-shared and @plasius/gpu-lock-free-queue dependencies to their latest released versions
- update the lockfile from npm registry
- document the dependency refresh in the changelog

## Validation
- npm run lint
- npm run typecheck
- npm run audit:npm
- npm run test:coverage
- npm run build
- npm run pack:check

Closes #9