### PR TITLE
chore: align gpu runtime dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ The format is based on **[Keep a Changelog](https://keepachangelog.com/en/1.1.0/
   - (placeholder)
 
 - **Changed**
+  - Updated runtime GPU dependencies to `@plasius/gpu-shared` `^1.0.2` and
+    `@plasius/gpu-lock-free-queue` `^0.3.3`.
   - (placeholder)
 
 - **Fixed**

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,8 +19,8 @@
       ],
       "license": "Apache-2.0",
       "dependencies": {
-        "@plasius/gpu-lock-free-queue": "^0.3.2",
-        "@plasius/gpu-shared": "^1.0.1"
+        "@plasius/gpu-lock-free-queue": "^0.3.3",
+        "@plasius/gpu-shared": "^1.0.2"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -731,9 +731,9 @@
       }
     },
     "node_modules/@plasius/gpu-lock-free-queue": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@plasius/gpu-lock-free-queue/-/gpu-lock-free-queue-0.3.2.tgz",
-      "integrity": "sha512-l+1jb31Fm/nelfWXN0qRsJICZeOfoWABEb4DDuJ2Pp4kYglio2h7vnWJ75l5FxD48ME8WU5DRGY6f5Gbayj6gg==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@plasius/gpu-lock-free-queue/-/gpu-lock-free-queue-0.3.3.tgz",
+      "integrity": "sha512-C5p+/8oOMpBM+omXJY7ytY4UL58pgr3KLnmrG3gWfV2fqJEwols0Rn0QP0klE4nbqEWIGRhA+1jJQb/hLC/0uw==",
       "funding": [
         {
           "type": "patreon",
@@ -746,47 +746,16 @@
       ],
       "license": "Apache-2.0",
       "dependencies": {
-        "@plasius/gpu-shared": "^0.1.9"
+        "@plasius/gpu-shared": "^1.0.2"
       },
       "engines": {
         "node": ">=24"
-      }
-    },
-    "node_modules/@plasius/gpu-lock-free-queue/node_modules/@plasius/gpu-shared": {
-      "version": "0.1.20",
-      "resolved": "https://registry.npmjs.org/@plasius/gpu-shared/-/gpu-shared-0.1.20.tgz",
-      "integrity": "sha512-YsZo1Id+UnVxr1YshrfI/N0DuVfkq7De+W9RZA5daM0STwgelh71G6Kk24Pv893g76nrBuyH0SyTgmhjMvAvTA==",
-      "funding": [
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/c/plasiusltd/membership"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/Plasius-LTD"
-        }
-      ],
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=24"
-      },
-      "peerDependencies": {
-        "@plasius/gpu-renderer": "^0.2.3",
-        "@plasius/translations": "^1.0.17"
-      },
-      "peerDependenciesMeta": {
-        "@plasius/gpu-renderer": {
-          "optional": true
-        },
-        "@plasius/translations": {
-          "optional": true
-        }
       }
     },
     "node_modules/@plasius/gpu-shared": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@plasius/gpu-shared/-/gpu-shared-1.0.1.tgz",
-      "integrity": "sha512-2+j6Gph/PuGmzTJJI/ZR8qGYfaEjLcN0+8zk/UEctVJyIb9+GMhE1Trkxg7L76qnaeO7g7LHAULwOuTTz5aOZQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@plasius/gpu-shared/-/gpu-shared-1.0.2.tgz",
+      "integrity": "sha512-3WyB97wGqM7+mVIqkT408aLUarkwv531TNGs1hRFFK3Xo0mj93O1hnL3lUL+gML0NqAkRIZvtKw489hBESdeRA==",
       "funding": [
         {
           "type": "patreon",
@@ -802,7 +771,7 @@
         "node": ">=24"
       },
       "peerDependencies": {
-        "@plasius/gpu-renderer": "^0.2.3",
+        "@plasius/gpu-renderer": "^0.2.22",
         "@plasius/translations": "^1.0.17"
       },
       "peerDependenciesMeta": {

--- a/package.json
+++ b/package.json
@@ -55,8 +55,8 @@
   "author": "Plasius LTD <development@plasius.co.uk>",
   "license": "Apache-2.0",
   "dependencies": {
-    "@plasius/gpu-lock-free-queue": "^0.3.2",
-    "@plasius/gpu-shared": "^1.0.1"
+    "@plasius/gpu-lock-free-queue": "^0.3.3",
+    "@plasius/gpu-shared": "^1.0.2"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",


### PR DESCRIPTION
Closes #37

## Summary
- Update @plasius/gpu-shared to ^1.0.2.
- Update @plasius/gpu-lock-free-queue to ^0.3.3 so worker installs no longer pull stale shared 0.x transitively.
- Refresh package-lock and changelog.

## Validation
- npm test
- npm run typecheck
- npm run lint
- npm run build
- npm run pack:check
- npm run audit:npm
- npm ls @plasius/gpu-shared --all --omit=dev